### PR TITLE
Standardise the login message

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -65,7 +65,7 @@ export const authOptions: NextAuthOptions = {
           const user = users[0] as User
           const isSuccess = await compare(password, user.hashedPassword)
           if (!isSuccess) {
-            throw Error('Incorrect password')
+            throw Error('Invalid email or password')
           }
 
           // The user object is passed to the session callback in session.data.user


### PR DESCRIPTION
# Description

When the user attempts to login with a wrong email, it shows an error saying that the email or password does not exist. However, when the user attempts to login with a correct email but a wrong password, it only says the password is wrong. For better security, it would be better to say that the email or password is wrong so that they do not know whether the account is valid and will not brute force in.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)