### PR TITLE
Fix applicant flow for acceptance

### DIFF
--- a/src/components/common/TopNavbar.tsx
+++ b/src/components/common/TopNavbar.tsx
@@ -42,10 +42,6 @@ const applicants = [
     href: '/tasks',
     title: 'Tasks',
   },
-  {
-    href: '/update-info',
-    title: 'Update information',
-  },
 ]
 
 const members = [

--- a/src/components/recruitment/applicant/AcceptRejectRoleModal.tsx
+++ b/src/components/recruitment/applicant/AcceptRejectRoleModal.tsx
@@ -15,6 +15,7 @@ import { ApplicationStatus } from '~/server/db/models/AppliedRole'
 import type { AppliedRole } from '~/server/db/models/AppliedRole'
 import { trpc } from '~/utils/trpc'
 import { delay } from '~/utils/common'
+import { useRouter } from 'next/router'
 
 const AcceptRejectRoleModal = ({
   applicantId,
@@ -29,6 +30,7 @@ const AcceptRejectRoleModal = ({
   buttonColor: string
   refetch: () => Promise<QueryObserverResult>
 }) => {
+  const router = useRouter()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { mutateAsync: mutateAppliedRoleAsync } =
     trpc.recruitment.updateAppliedRoleStatus.useMutation()
@@ -40,13 +42,6 @@ const AcceptRejectRoleModal = ({
         decision === 'accept'
           ? ApplicationStatus.ACCEPTED
           : ApplicationStatus.REJECTED
-
-      const firstToast = toast({
-        duration: null,
-        status: 'loading',
-        title: 'Updating',
-        description: 'Waiting to update...',
-      })
   
       // Update the appliedRole and the user information
       await mutateAppliedRoleAsync({
@@ -56,7 +51,6 @@ const AcceptRejectRoleModal = ({
       })
 
       await refetch()
-      toast.close(firstToast)
       toast({
         duration: 2000,
         status: 'success',

--- a/src/components/recruitment/applicant/AcceptRejectRoleModal.tsx
+++ b/src/components/recruitment/applicant/AcceptRejectRoleModal.tsx
@@ -10,16 +10,12 @@ import {
   useDisclosure,
   useToast,
 } from '@chakra-ui/react'
-import { signOut } from 'next-auth/react'
 import type { QueryObserverResult } from '@tanstack/react-query'
 import { useRouter } from 'next/router'
 import { ApplicationStatus } from '~/server/db/models/AppliedRole'
 import type { AppliedRole } from '~/server/db/models/AppliedRole'
 import { trpc } from '~/utils/trpc'
-
-const delay = (ms: number) => {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
+import { delay } from '~/utils/common'
 
 const AcceptRejectRoleModal = ({
   applicantId,
@@ -78,12 +74,11 @@ const AcceptRejectRoleModal = ({
         toast({
           duration: 2000,
           status: 'success',
-          title: 'Re-login',
-          description: `You are now a member. We will require a re-login so you'll be logged out shortly`,
+          title: 'Update Info',
+          description: `You are now a member! You'll be redirected shortly to update your information`,
         })
         await delay(3000)
-        // need to force him to re-login in order for nextauth to update him from applicant to member
-        await signOut()
+        router.push('/update-info')
       }
     } catch (e) {
       toast({

--- a/src/components/recruitment/director/StatusPopup.tsx
+++ b/src/components/recruitment/director/StatusPopup.tsx
@@ -105,22 +105,6 @@ const StatusPopup = ({
           <UnorderedList styleType="none">
             <ListItem className="flex items-center">
               <IconButton
-                aria-label="accepted status"
-                icon={<BsCircleFill fill="#46FFDE" />}
-                bg="None"
-                _hover={{ background: 'None' }}
-                marginLeft="2"
-                onClick={() => {
-                  setIsAcceptOpen(true)
-                  setStatusInModal(
-                    ApplicationStatus.ACCEPTED as ApplicationStatus
-                  )
-                }}
-              />
-              <Text>Accepted</Text>
-            </ListItem>
-            <ListItem className="flex items-center">
-              <IconButton
                 aria-label="offered status"
                 icon={<BsCircleFill fill="#0038FF" />}
                 bg="None"

--- a/src/components/recruitment/director/StatusPopup.tsx
+++ b/src/components/recruitment/director/StatusPopup.tsx
@@ -43,8 +43,7 @@ const StatusPopup = ({
   refetch: () => Promise<QueryObserverResult>
 }) => {
   const toast = useToast()
-  const { mutateAsync } =
-    trpc.recruitment.updateAppliedRoleStatusWithEmail.useMutation()
+  const { mutateAsync } = trpc.recruitment.updateAppliedRoleStatus.useMutation()
   const [currentStatus, setCurrentStatus] = useState(appliedRole.status)
   const [statusInModal, setStatusInModal] = useState(appliedRole.status)
   const [isAcceptOpen, setIsAcceptOpen] = useState(false)
@@ -63,10 +62,7 @@ const StatusPopup = ({
       await mutateAsync({
         status: status,
         appliedRoleId: appliedRole.id,
-        name: applicant.name,
-        email: applicant.email,
-        appliedRole: appliedRole.role,
-        appliedDepartment: appliedRole.department,
+        applicantId: applicant.id
       })
       await refetch()
       setCurrentStatus(status)

--- a/src/pages/update-info.tsx
+++ b/src/pages/update-info.tsx
@@ -18,6 +18,8 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import withApplicantAuth, { type BaseProps } from '~/utils/withApplicantAuth'
 import { getSession } from 'next-auth/react'
 import { type GetServerSidePropsContext } from 'next'
+import { delay } from '~/utils/common'
+import { signOut } from 'next-auth/react'
 
 const UpdateInfoPage: React.FC<BaseProps> = ({ session }) => {
   const router = useRouter()
@@ -75,8 +77,15 @@ const UpdateInfoPage: React.FC<BaseProps> = ({ session }) => {
         title: 'Success',
         description: 'User profile has been successfully updated',
       })
-
-      redirectHome()
+      toast({
+        duration: 2000,
+        status: 'success',
+        title: 'Re-login',
+        description: `We will require a re-login so you'll be logged out shortly`,
+      })
+      await delay(3000)
+      // need to force him to re-login in order for nextauth to update him from applicant to member
+      await signOut()
     } catch (e) {
       toast({
         description: (e as Error).message,

--- a/src/server/db/collections/BaseCollection.ts
+++ b/src/server/db/collections/BaseCollection.ts
@@ -98,7 +98,7 @@ export abstract class BaseCollection<T> {
       },
       get: async (id: string) => {
         const result = await transaction.get(doc(db, this.collectionName, id))
-        return { ...result.data, id: result.id } as T
+        return { ...result.data(), id: result.id } as T
       },
       update: (payload: Partial<T>, id: string) => {
         transaction.update(

--- a/src/server/db/models/Task.ts
+++ b/src/server/db/models/Task.ts
@@ -2,7 +2,7 @@ import type { Timestamp } from 'firebase/firestore'
 import type User from './Event'
 
 export type Task = {
-  status: string
+  status: string | null
   id?: string
   due: Timestamp
   taskName: string

--- a/src/server/trpc/router/recruitment/createTask.ts
+++ b/src/server/trpc/router/recruitment/createTask.ts
@@ -46,7 +46,7 @@ export const createTask = protectedProcedure
               description: input.description,
               department: input.departments,
               taskCreatorId: ctx.session.user.id,
-              taskCreatorName: user.name,
+              taskCreatorName: taskCreator.name,
             }
 
             if (user.pendingTask) {

--- a/src/server/trpc/router/recruitment/index.ts
+++ b/src/server/trpc/router/recruitment/index.ts
@@ -1,7 +1,6 @@
 import { router } from '~/server/trpc/trpc'
 import {
   updateAppliedRoleStatus,
-  updateAppliedRoleStatusWithEmail,
   updateInterviewNotes,
   updateAppliedRoleFlag,
 } from './update'
@@ -19,7 +18,6 @@ import { createTask } from './createTask'
 
 export const recruitmentRouter = router({
   updateAppliedRoleStatus,
-  updateAppliedRoleStatusWithEmail,
   updateInterviewNotes,
   updateAppliedRoleFlag,
   getAllApplicantsTopRoleByDept,

--- a/src/server/trpc/router/recruitment/index.ts
+++ b/src/server/trpc/router/recruitment/index.ts
@@ -4,7 +4,6 @@ import {
   updateAppliedRoleStatusWithEmail,
   updateInterviewNotes,
   updateAppliedRoleFlag,
-  updateApplicantToMember,
 } from './update'
 import {
   getAllApplicantsTopRoleByDept,
@@ -23,7 +22,6 @@ export const recruitmentRouter = router({
   updateAppliedRoleStatusWithEmail,
   updateInterviewNotes,
   updateAppliedRoleFlag,
-  updateApplicantToMember,
   getAllApplicantsTopRoleByDept,
   getApplicant,
   getAppliedRoleByRoleId,

--- a/src/server/trpc/router/recruitment/read.ts
+++ b/src/server/trpc/router/recruitment/read.ts
@@ -16,16 +16,9 @@ import { protectedProcedure } from '~/server/trpc/trpc'
  * point in time, from the perspective of a director.
  * */
 export const getAllApplicantsTopRoleByDept = protectedProcedure
-  //.input(z.object({
-  //   filter: z.string(),
-  //   search: z.string()
-  // }))
   .query(async ({ ctx }) => {
     try {
       const filtersForUsers = [where('role', '==', 'Applicant')]
-      // if (input.search && input.search.length) {
-      //   filtersForUsers.push(where('name', '==', input.search))
-      // }
       const applicants = await userCollection.queries(filtersForUsers)
       const applicantsWithRoles: Applicant[] = []
 

--- a/src/server/trpc/router/recruitment/update.ts
+++ b/src/server/trpc/router/recruitment/update.ts
@@ -37,7 +37,6 @@ export const updateAppliedRoleStatus = protectedProcedure
             .get(input.applicantId)
         ])
 
-        console.log(40, input.appliedRoleId)
         /// Update the applied role with the status.
         appliedRoleCollection.withTransaction(transaction).update({
             status: input.status,

--- a/src/server/trpc/router/recruitment/update.ts
+++ b/src/server/trpc/router/recruitment/update.ts
@@ -5,18 +5,93 @@ import appliedRoleCollection from '~/server/db/collections/AppliedRoleCollection
 import { ApplicationStatus } from '~/server/db/models/AppliedRole'
 import { sendOfferEmail, sendRejectionEmail } from './helper'
 import userCollection from '~/server/db/collections/UserCollection'
+import taskCollection from '~/server/db/collections/TaskCollection'
+import { Timestamp, runTransaction, where } from 'firebase/firestore'
+import { db } from '~/server/db/firebase'
+import type { User } from '~/server/db/models/User'
+import type Task from '~/server/db/models/Task'
 
 export const updateAppliedRoleStatus = protectedProcedure
   .input(
     z.object({
       appliedRoleId: z.string(),
+      applicantId: z.string(),
       status: z.nativeEnum(ApplicationStatus),
     })
   )
-  .mutation(async ({ input }) => {
-    try {
-      await appliedRoleCollection.update(input.appliedRoleId, {
-        status: input.status,
+  .mutation(async ({ input, ctx }) => {
+    try {  
+      /// If the user is an admin, he cannot accept the offer for the applicant.
+      if (ctx.session.user.id !== input.applicantId) {
+        throw Error('An admin user should not be able to accept the offer for the applicant.')
+      }
+
+      await runTransaction(db, async (transaction) => {
+        /// Get the details for the applied role. We check whether the signed in user
+        const [role, applicant] = await Promise.all([
+          appliedRoleCollection
+            .withTransaction(transaction)
+            .get(input.appliedRoleId),
+          userCollection
+            .withTransaction(transaction)
+            .get(input.applicantId)
+        ])
+
+        console.log(40, input.appliedRoleId)
+        /// Update the applied role with the status.
+        appliedRoleCollection.withTransaction(transaction).update({
+            status: input.status,
+          }, input.appliedRoleId)
+
+        /// If the user accepts his status, we give him the department and role.
+        if (input.status === ApplicationStatus.ACCEPTED) {
+          const isAdmin =
+            role.role === 'Co-Director' ||
+            role.role === 'Director' ||
+            role.department === 'Internal Affairs'
+
+          const payload: Partial<User> = {
+            isAdmin,
+            role: role.role,
+            department: role.department,
+          }
+
+          /// If the user is not admin, we have to give him all the non-expired task and
+          /// update the task collection accordingly.
+          if (!isAdmin) {
+            const pendingTask = await taskCollection.queries([
+              where("department", "array-contains", role.department),
+              where("due", ">", Timestamp.fromDate(new Date()))
+            ])
+
+            payload.pendingTask = pendingTask
+
+            pendingTask.forEach((task) => {
+              const taskPayload: Partial<Task> = {}
+
+              if (task.taskCompletion !== undefined) {
+                taskPayload.taskCompletion = task.taskCompletion + 1
+                taskPayload.status = taskPayload.status === "done" ? null : "done"
+              }
+
+              const assignedUser = {
+                completed: false,
+                department: role.department,
+                id: applicant.id,
+                name: applicant.name,
+                role: role.role
+              }
+
+              taskPayload.assignedUsers = task.assignedUsers 
+                ? [...task.assignedUsers, assignedUser] 
+                : [assignedUser]
+
+              taskCollection.withTransaction(transaction).update(taskPayload, task.id as string)
+            })
+          }
+
+          userCollection.withTransaction(transaction).update(payload, role.applicantId)
+        }
       })
     } catch (e) {
       throw new TRPCError({
@@ -97,28 +172,6 @@ export const updateAppliedRoleFlag = protectedProcedure
     try {
       return await appliedRoleCollection.update(input.appliedRoleId, {
         flag: input.flag,
-      })
-    } catch (e) {
-      throw new TRPCError({
-        code: 'INTERNAL_SERVER_ERROR',
-        message: (e as Error).message,
-      })
-    }
-  })
-
-export const updateApplicantToMember = protectedProcedure
-  .input(
-    z.object({
-      applicantId: z.string(),
-      role: z.string(),
-      department: z.string(),
-    })
-  )
-  .mutation(async ({ input }) => {
-    try {
-      return await userCollection.update(input.applicantId, {
-        role: input.role,
-        department: input.department,
       })
     } catch (e) {
       throw new TRPCError({

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,3 @@
+export const delay = (ms: number) => {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
# Description
Changes made:

1. Upon acceptance from the applicant, the applicant will be redirected to the update information page under the route `/update-info`
2. Once the submit button is clicked on the update information page, the applicant will be logged out as nextauth requires a re-login to update the value of `isApplicant`. The reason for this is that the `role: Applicant` which we use for identifying applicants is now updated to the `role: <Accepted Role>`, and nextAuth uses the boolean of `isApplicant = applicant.role == 'Applicant'` to separate applicants from fintech members.
3. The `Update Information` tab in the Applicant's view of the navbar is now removed as we'd use the update information page under the `update-info` route purely for when the applicant accepts the role and has to update their information.
4. Removed the `Accepted` status from the director's `Manage Applicant` page, as the applicants are the ones that have control over this status and not the directors. The directors will give the `Offered` status for applicants. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
