### PR TITLE
Fix up the UIUX and the bug for edit modal

### DIFF
--- a/src/components/users/EditModal.tsx
+++ b/src/components/users/EditModal.tsx
@@ -17,7 +17,7 @@ import {
 import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/router'
 import { trpc } from '~/utils/trpc'
-import { useContext, useCallback, useState } from 'react'
+import { useContext, useCallback } from 'react'
 import { ModalContext } from '~/context/ModalContext'
 import type { User } from '~/server/db/models/User'
 import { roles } from '~/constant/roles'
@@ -26,36 +26,43 @@ const EditModal = () => {
   const modal = useContext(ModalContext)
   const toast = useToast()
   const router = useRouter()
-  const [department, setDepartment] = useState('')
+
   const { register, handleSubmit } = useForm({
     mode: 'onSubmit',
   })
 
-  const { data, isLoading, refetch } = trpc.user.getUserProfile.useQuery(
+  const { data, isLoading } = trpc.user.getUserProfile.useQuery(
     modal.id
   )
   const { mutateAsync, isLoading: loading } =
     trpc.user.updateUserProfile.useMutation()
+  const { refetch } = trpc.user.getAllUsersForTable.useQuery()
 
   const onSubmit = useCallback(
     async (formData: Partial<User>) => {
       try {
-        const projData = {
+        const filteredRoles = roles.filter(role => role.role === formData.role)
+
+        const department = filteredRoles.length === 1 ? filteredRoles[0]?.department : data?.department
+
+        await mutateAsync({
           id: data?.id as string,
           name: formData.name as string,
           email: formData.email as string,
-          department,
+          department: department as string,
           role: formData.role as string,
-        }
-        await mutateAsync(projData)
+        })
+
         await refetch()
+
         toast({
-          duration: 9000,
+          duration: 3000,
           description: 'User has been successfully updated',
           title: 'Successfully updated',
           status: 'success',
         })
-        router.push('./')
+
+        modal.onClose()
       } catch (e) {
         toast({
           duration: 9000,
@@ -65,7 +72,7 @@ const EditModal = () => {
         })
       }
     },
-    [mutateAsync, data?.id, toast, department, refetch, router]
+    [mutateAsync, data?.id, toast, data?.department, router, refetch]
   )
 
   if (!modal.id || isLoading) return null
@@ -88,7 +95,7 @@ const EditModal = () => {
                 defaultValue={(data as User).name}
               />
 
-              <FormLabel fontWeight={'semibold'}>Email address</FormLabel>
+              <FormLabel fontWeight={'semibold'}>NUS Email</FormLabel>
               <Input
                 mb={'5'}
                 {...register('email')}
@@ -102,14 +109,6 @@ const EditModal = () => {
                 isRequired
                 defaultValue={(data as User).role}
                 {...register('role')}
-                onChange={(e) => {
-                  if (!e.target.value) return
-                  const element = roles.filter(
-                    (role) => role.role === e.target.value
-                  )
-                  if (!element || !element.length || !element[0]) return
-                  setDepartment(element[0].department)
-                }}
                 placeholder="Select role"
               >
                 {roles.map((role, index) => {

--- a/src/components/users/EditModal.tsx
+++ b/src/components/users/EditModal.tsx
@@ -41,9 +41,9 @@ const EditModal = () => {
   const onSubmit = useCallback(
     async (formData: Partial<User>) => {
       try {
-        const filteredRoles = roles.filter(role => role.role === formData.role)
+        const filteredRole = roles.find(role => role.role === formData.role)
 
-        const department = filteredRoles.length === 1 ? filteredRoles[0]?.department : data?.department
+        const department = filteredRole ? filteredRole.department : data?.department
 
         await mutateAsync({
           id: data?.id as string,

--- a/src/server/trpc/router/users/updateUserProfile.ts
+++ b/src/server/trpc/router/users/updateUserProfile.ts
@@ -8,6 +8,7 @@ export const updateUserProfile = protectedProcedure
     z.object({
       id: z.string(),
       name: z.string(),
+      email: z.string(),
       role: z.string(),
       department: z.string(),
     })
@@ -21,6 +22,7 @@ export const updateUserProfile = protectedProcedure
       }
 
       await userCollection.update(input.id, {
+        email: input.email,
         department: input.department,
         name: input.name,
         role: input.role,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- I fixed the bug where the department gets removed. The issue with it is that the initial state of useState is an empty string. If we do not set an initial value and change other values and attempt to update it, we will be updating the department with an empty string. The solution to that is to set the department to the user's original department and instead of doing onChange, we get the department by finding the role and determining which department it belongs to.

- I also fixed up the bug where the NUS email cannot be changed. It is allowable now since we are just storing the NUS email for collection purposes.

- I fixed up the UIUX for the edit user page. Basically after you edit, instead of refreshing the whole page, it will update the table and close the modal.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)