### PR TITLE
fix width for cards to ensure standardised size

### DIFF
--- a/src/components/department/MemberCard.tsx
+++ b/src/components/department/MemberCard.tsx
@@ -14,7 +14,7 @@ import type { User } from '~/server/db/models/User'
 const MemberCard = ({ member }: { member: User }) => {
   return (
     <Card
-      maxWidth="250px"
+      width="280px"
       borderRadius="20"
       boxShadow="0px 4px 4px rgba(0, 0, 0, 0.25)"
       minHeight="250px"

--- a/src/components/recruitment/director/ApplicantCard.tsx
+++ b/src/components/recruitment/director/ApplicantCard.tsx
@@ -71,7 +71,7 @@ const ApplicantCard = ({ applicant }: { applicant: Applicant }) => {
   }
   return (
     <Card
-      maxWidth="280px"
+      width="280px"
       borderRadius="20"
       boxShadow="0px 4px 4px rgba(0, 0, 0, 0.25)"
       minHeight="310px"


### PR DESCRIPTION
# Description

Cards for member and applicant under the department and recruitment tabs respectively were not fixed width, which caused the width to vary between different cards if the name of the applicant was longer or other text was shorter etc.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
